### PR TITLE
fix: proper esm typings declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "typings": "./build/index.d.ts",
   "exports": {
     ".": {
+      "types": "./build/index.d.ts",
       "import": "./build/index.mjs",
       "require": "./build/index.js"
     }


### PR DESCRIPTION
basically re-opening #15 - i can't use `@colyseus/command` in my typescript set-up given it doesn't properly expose typings